### PR TITLE
Build image with latest golang

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # This docker file is for local dev, the official Dockerfile is at
 # https://github.com/trickstercache/trickster-docker-images/
 
-FROM golang:1.20 as builder
+FROM golang:1 as builder
 COPY . /go/src/github.com/trickstercache/trickster
 WORKDIR /go/src/github.com/trickstercache/trickster
 


### PR DESCRIPTION
docker build needs at least the same version of golang as what is set in go modules, but is currently one minor release behind. Building with latest golang makes it easier to manage.